### PR TITLE
Chart: gnuplot size option

### DIFF
--- a/lib/how_is/reporter.rb
+++ b/lib/how_is/reporter.rb
@@ -60,7 +60,7 @@ module HowIs
           end
 
           Chart.gnuplot(%Q{
-            set terminal png size 500x500
+            set terminal png size 500,500
             set output 'issues-per-label.png'
             set nokey
             unset border


### PR DESCRIPTION
This trivial change makes the ratio option avoid a gnuplot warning.

(I'm trying this program on OS X.)

```
> $ gnuplot --version
gnuplot 5.0 patchlevel 3
```