### PR TITLE
Rotate images with MiniMagick

### DIFF
--- a/data/issues.plg
+++ b/data/issues.plg
@@ -1,17 +1,22 @@
+if (!exists("chartsize")) chartsize = '500,500'
+if (!exists("labelfont")) labelfont = 'Helvetica,12'
+if (!exists("chartfont")) chartfont = 'Helvetica,12'
+if (!exists("data")) data = 'issues-per-label.dat'
+
 set terminal png size chartsize font chartfont
 
 set output 'issues-per-label.png'
-
-set lmargin at screen 0.15
-set bmargin at screen 0.15
-set rmargin at screen 0.85
-set tmargin at screen 0.85
 
 unset key
 unset border
 set tics nomirror
 unset xtics
 
-plot 'issues-per-label.dat' using 1:(-1):3 with labels left rotate by 90 font labelfont offset 0,1.5, \
-     'issues-per-label.dat' using 1:2 with boxes
+plot data using 1:(-1):3 with \
+      labels left \
+      rotate by 90 \
+      font labelfont \
+      offset 0.30,2.10, \
+     data using 1:2 with boxes
+
 

--- a/data/issues.plg
+++ b/data/issues.plg
@@ -9,6 +9,7 @@ set tmargin at screen 0.85
 
 unset key
 unset border
+set tics nomirror
 unset xtics
 
 plot 'issues-per-label.dat' using 1:(-1):3 with labels left rotate by 90 font labelfont offset 0,1.5, \

--- a/data/issues.plg
+++ b/data/issues.plg
@@ -12,11 +12,14 @@ unset border
 set tics nomirror
 unset xtics
 
-plot data using 1:(-1):3 with \
+set style fill solid 0.25 border
+
+plot data using 1:2 with boxes, \
+     data using 1:(-1):3 with \
       labels left \
       rotate by 90 \
       font labelfont \
-      offset 0.30,2.10, \
-     data using 1:2 with boxes
+      offset 0.30,1.10
+
 
 

--- a/data/issues.plg
+++ b/data/issues.plg
@@ -12,14 +12,11 @@ unset border
 set tics nomirror
 unset xtics
 
-set style fill solid 0.25 border
+set style fill solid 0.15 border
 
-plot data using 1:2 with boxes, \
-     data using 1:(-1):3 with \
+plot data using 1:2 with boxes, data using 1:(0):3 with \
       labels left \
       rotate by 90 \
       font labelfont \
-      offset 0.30,1.10
-
-
+      offset 0,0.45
 

--- a/data/issues.plg
+++ b/data/issues.plg
@@ -1,0 +1,16 @@
+set terminal png size chartsize font chartfont
+
+set output 'issues-per-label.png'
+
+set lmargin at screen 0.15
+set bmargin at screen 0.15
+set rmargin at screen 0.85
+set tmargin at screen 0.85
+
+unset key
+unset border
+unset xtics
+
+plot 'issues-per-label.dat' using 1:(-1):3 with labels left rotate by 90 font labelfont offset 0,1.5, \
+     'issues-per-label.dat' using 1:2 with boxes
+

--- a/how_is.gemspec
+++ b/how_is.gemspec
@@ -24,6 +24,8 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "prawn"
   spec.add_runtime_dependency "prawn-table"
 
+  spec.add_runtime_dependency "mini_magick"
+
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/lib/how_is/chart.rb
+++ b/lib/how_is/chart.rb
@@ -14,7 +14,7 @@ class HowIs::Chart
 
   def self.rotate_with_dotnet(filename, offset)
     ps_rotate_flip = {
-      90 => 'Rotate90FlipNone',
+      90  => 'Rotate90FlipNone',
       180 => 'Rotate180FlipNone',
       270 => 'Rotate270FlipNone',
       -90 => 'Rotate270FlipNone'

--- a/lib/how_is/chart.rb
+++ b/lib/how_is/chart.rb
@@ -1,6 +1,30 @@
 class HowIs::Chart
-  def self.gnuplot(commands)
-    IO.popen("gnuplot", "w") {|io| io.puts commands}
+  # Generates the gnuplot script in data/issues.plg.
+  #
+  # Some configuration is available. Font locations are path to a TTF or other
+  # Gnuplot-readable font name.
+  #
+  # For example that could be '/Users/anne/Library/Fonts/InputMono-Medium.ttf'
+  # or just 'Helvetica'.
+  #
+  # @param font_location [String] Font for the chart
+  # @param font_size [Integer] Size of the chart text
+  # @param label_font_location [String] Font for labels
+  # @param label_font_size [Integer] Size of the label text
+  #
+  # @return void
+  def self.gnuplot(font_location: 'Helvetica',
+                   font_size: 16,
+                   label_font_location: 'Helvetica',
+                   label_font_size: 10,
+                   chartsize: '500,500')
+    cmd = %Q{
+      gnuplot -e "labelfont='#{label_font_location},#{label_font_size}'" \
+              -e "chartfont='#{font_location},#{font_size}'" \
+              -e "chartsize='#{chartsize}'" \
+              -c data/issues.plg
+    }
+    IO.popen(cmd, 'w')
   end
 
   def self.rotate(offset, filename)

--- a/lib/how_is/chart.rb
+++ b/lib/how_is/chart.rb
@@ -28,7 +28,7 @@ class HowIs::Chart
   end
 
   def self.rotate(offset, filename)
-    if on_windows?
+    if Gem.win_platform?
       rotate_with_dotnet(filename, offset)
     else
       rotate_with_minimagick(filename, offset)
@@ -65,9 +65,5 @@ class HowIs::Chart
     image = MiniMagick::Image.new(filename) { |b| b.rotate offset.to_s }
     image.format 'png'
     image.write filename
-  end
-
-  def self.on_windows?
-    %w(mswin32 mingw32).include? Gem::Platform.local.os
   end
 end

--- a/lib/how_is/chart.rb
+++ b/lib/how_is/chart.rb
@@ -33,7 +33,6 @@ class HowIs::Chart
     else
       rotate_with_minimagick(filename, offset)
     end
-    $stderr.puts "Rotated image #{offset} degrees."
   end
 
   def self.rotate_with_dotnet(filename, offset)

--- a/lib/how_is/chart.rb
+++ b/lib/how_is/chart.rb
@@ -4,6 +4,7 @@ class HowIs::Chart
   end
 
   def self.rotate(offset, filename)
+    return unless on_windows?
     ps_rotate_flip = {
       90  => 'Rotate90FlipNone',
       180 => 'Rotate180FlipNone',
@@ -27,5 +28,9 @@ class HowIs::Chart
     IO.popen(["powershell", "-Command", command], 'w') { |io|
     }
     $stderr.puts "Rotated image #{offset} degrees."
+  end
+
+  def self.on_windows?
+    %w(mswin32 mingw32).include? Gem::Platform.local.os
   end
 end

--- a/lib/how_is/chart.rb
+++ b/lib/how_is/chart.rb
@@ -4,9 +4,17 @@ class HowIs::Chart
   end
 
   def self.rotate(offset, filename)
-    return unless on_windows?
+    if on_windows?
+      rotate_with_dotnet(filename, offset)
+    else
+      rotate_with_minimagick(filename, offset)
+    end
+    $stderr.puts "Rotated image #{offset} degrees."
+  end
+
+  def self.rotate_with_dotnet(filename, offset)
     ps_rotate_flip = {
-      90  => 'Rotate90FlipNone',
+      90 => 'Rotate90FlipNone',
       180 => 'Rotate180FlipNone',
       270 => 'Rotate270FlipNone',
       -90 => 'Rotate270FlipNone'
@@ -25,9 +33,14 @@ class HowIs::Chart
       exit
     }
 
-    IO.popen(["powershell", "-Command", command], 'w') { |io|
-    }
-    $stderr.puts "Rotated image #{offset} degrees."
+    IO.popen(["powershell", "-Command", command], 'w') { |io| }
+  end
+
+  def self.rotate_with_minimagick(filename, offset)
+    require 'mini_magick'
+    image = MiniMagick::Image.new(filename) { |b| b.rotate offset.to_s }
+    image.format 'png'
+    image.write filename
   end
 
   def self.on_windows?

--- a/lib/how_is/reporter.rb
+++ b/lib/how_is/reporter.rb
@@ -60,7 +60,7 @@ module HowIs
           end
 
           Chart.gnuplot(%Q{
-            set terminal png size 500x500
+            set terminal png size 500,500
             set output 'issues-per-label.png'
             set nokey
             unset border

--- a/lib/how_is/reporter.rb
+++ b/lib/how_is/reporter.rb
@@ -59,16 +59,10 @@ module HowIs
             end
           end
 
-          Chart.gnuplot(%Q{
-            set terminal png size 500,500
-            set output 'issues-per-label.png'
-            set nokey
-            unset border
-            unset xtics
-
-            plot 'issues-per-label.dat' using 1:(-1):3 with labels rotate right, \
-                 'issues-per-label.dat' using 1:2 with boxes
-            })
+          Chart.gnuplot(label_font_location: 'Helvetica',
+                        label_font_size: 10,
+                        font_location: 'Helvetica',
+                        font_size: 16)
           Chart.rotate(90, 'issues-per-label.png')
 
           image "./issues-per-label.png"

--- a/lib/how_is/reporter.rb
+++ b/lib/how_is/reporter.rb
@@ -55,7 +55,7 @@ module HowIs
 
           File.open('issues-per-label.dat', 'w') do |f|
             issues_per_label.each_with_index do |(label, n), i|
-              f.puts "#{i}\t#{n}\t#{label}"
+              f.puts "#{i}\t#{n}\t\"#{label}\""
             end
           end
 


### PR DESCRIPTION
- Developer ergonomics: a separate gnuplot script allows for more rapid feedback when fiddling with settings on it. That script is in `data/issues.plg` and takes parameters, but has defaults
- Support: on non-Windows, rotate images using mini_magick (a shell wrapper, not a C binding)
- Fix: GitHub labels can have spaces in them, so double-quote them in the `issues-per-label.dat`

---

When iterating to a plot I liked, I passed settings to gnuplot using `-e`:

```shell
gnuplot -e "labelfont='/Users/olle/Library/Fonts/InputMono-Medium.ttf,10'" \
        -e "chartfont='/Users/olle/Library/Fonts/InputMono-Medium.ttf,16'" \
        -c data/issues.plg \
        && open issues-per-label.png
```

(When you've once visited a GitHub project which has cool .dat data with it, you rerun this command many times over without going to the net.)

I added a little offset to the labels, so that they appear over their bars. Easy to tweak. Here is an early example.

![issues-per-label](https://cloud.githubusercontent.com/assets/211/15942008/dc301126-2e82-11e6-9ea0-03c4ba59152d.png)

With some more tweaking (this was fun!):

<img width="593" alt="screenshot 2016-06-09 21 58 49" src="https://cloud.githubusercontent.com/assets/211/15944332/6b587b72-2e8d-11e6-9724-0b9e82d1410e.png">

With even more tweaking the 0 is the origin:

<img width="667" alt="screenshot 2016-06-09 22 36 20" src="https://cloud.githubusercontent.com/assets/211/15945416/aeed9c50-2e92-11e6-967d-92c29cedffe3.png">


---