### PR TITLE
Executable: Fail faster, use abort

### DIFF
--- a/exe/how_is
+++ b/exe/how_is
@@ -3,7 +3,10 @@
 require "how_is"
 require "optparse"
 
+abort "Error: No repository specified." unless ARGV.size == 1
+
 options = {
+  repository: ARGV.delete_at(0),
   report_file:  "report.pdf",
   from_file: nil,
 }
@@ -37,12 +40,5 @@ opts = OptionParser.new do |opts|
   end
 end
 opts.parse!
-
-if ARGV.length == 1
-  options[:repository] = ARGV.delete_at(0)
-else
-  puts "Error: No repository specified."
-  exit 1
-end
 
 HowIs.generate_report(options)


### PR DESCRIPTION
In the PR, the ordering of code makes the definition of the options Hash sit in one place.

Using abort to fail with an exit code -1 and a message.